### PR TITLE
Fix CI build: generate `token.config` from GitHub Secrets during GitHub Actions tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,7 +31,12 @@ jobs:
       - name: Create token.config for tests
         run: |
           mkdir -p ci-server/src/test/resources
-          printf "%s" "${{ secrets.STATUS_POSTER_TOKEN }}" > ci-server/src/test/resources/token.config
+          cat > ci-server/src/test/resources/token.config <<EOF
+          owner=${{ github.repository_owner }}
+          repo=${{ github.event.repository.name }}
+          token=${{ secrets.API_TOKEN }}
+          EOF
+
 
       - name: Build + Test
         run: mvn -B clean test --file ci-server/pom.xml


### PR DESCRIPTION

# Description


## Problem
GitHub Actions test runs failed because `StatusPoster` expects a `token.config` file on the classpath.  
Locally the file exists, but it is intentionally not committed (contains sensitive token data). In CI, the file was missing/invalid, causing `StatusPosterTest` to throw `IllegalStateException` and fail the build.

## Changes Made
- Added a workflow step to **create `ci-server/src/test/resources/token.config` at runtime** during GitHub Actions.
- The file is generated from existing GitHub Actions context + repo secrets:
  - `token` from `secrets.API_TOKEN` (already present in repo secrets)
  - `owner` from `${{ github.repository_owner }}`
  - `repo` from `${{ github.event.repository.name }}`
- Ensured the file is created **before running Maven**, so tests can load it from the classpath.

## Security Notes
- `token.config` is still **not committed** to the repository.
- Secrets remain stored in **GitHub Secrets** and are only injected at runtime in CI.
- The file is created under `src/test/resources` so it’s used only for tests and is not meant for production packaging.
