### PR TITLE
fix: specify release (Closes #38)

### DIFF
--- a/ci-server/pom.xml
+++ b/ci-server/pom.xml
@@ -9,8 +9,7 @@
   <url>http://maven.apache.org</url>
 
   <properties>
-        <maven.compiler.source>19</maven.compiler.source>
-        <maven.compiler.target>19</maven.compiler.target>
+        <maven.compiler.release>19</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 


### PR DESCRIPTION
## Summary
Fix the warning `Warning:  system modules path not set in conjunction with -source 19` by specifying the `release` in `pom.xml`.

## Verification
No warnings in the remote build logs