### PR TITLE
Went through the API and added some missing javadocs

### DIFF
--- a/ci-server/src/main/java/com/ci/DbHandler.java
+++ b/ci-server/src/main/java/com/ci/DbHandler.java
@@ -45,6 +45,11 @@ public class DbHandler {
         this.dbUrl = "jdbc:sqlite:"+dbUrl;
     }
 
+    /**
+     * Establishes a connection to the database.
+     * @return a Connection object to the database
+     * @throws SQLException
+     */
     protected Connection getConnection() throws SQLException {
         return DriverManager.getConnection(dbUrl);
     }

--- a/ci-server/src/main/java/com/ci/pipeline/CommandRunner.java
+++ b/ci-server/src/main/java/com/ci/pipeline/CommandRunner.java
@@ -11,6 +11,13 @@ import java.util.Comparator;
  * Also provides a utility method for deleting directories recursively.
  */
 public class CommandRunner {
+
+    /**
+     * A record to hold the result of a command execution, including the exit code and logs.
+     * 
+     * @param exitCode the exit code of the command
+     * @param logs the combined standard output and error logs from the command execution
+     */
     public record TestResult(int exitCode, String logs) {}
 
     /**


### PR DESCRIPTION
## Summary
- Went through the API
- Added some missing documentation to `getConnection()` of DbHandler and `TestResult` of CommandRunner. (probably was not needed, but just to be sure)

## All functions seem to have javadocs, everything seems to be properly documented, nice job :heart: 

Closes #72 